### PR TITLE
On error integration test

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,6 +16,7 @@
 """Default fixtures for functional tests."""
 
 from functools import partial
+import os
 from pathlib import Path
 import re
 from shutil import rmtree
@@ -23,6 +24,8 @@ from shutil import rmtree
 import pytest
 
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow import LOG
+from cylc.flow.scheduler_cli import _close_logs
 from cylc.flow.wallclock import get_current_time_string
 
 from . import (
@@ -74,20 +77,13 @@ def _pytest_passed(request):
 
 def onerror(func, path, exc_info):
     """Callback function for shutil rmtree
-        This solves NFS problems"""
-    import os
-    from pathlib import Path
-    from shutil import rmtree
-    from cylc.flow import LOG
+        This hides from NFS problems"""
     try:
-        # get parent folder of path and give
-        tmp = Path(path)
-        os.chmod(tmp.parent, 0o700)
+        _close_logs()
         func(path)
     except Exception as ex:
         LOG.error(f"Error deleting {path}", ex)
         rmtree(path, ignore_errors=True)
-
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
I think this commit will fix the nfs issue.

Basically uses the onerror callback in rmtree, when it hits an error, it will close the logs and re-try deleting. This works on my machine, even with the except rmtree ignore errors hashed out - that is there for saftey.

It doesn't solve the underlying issue for cylc, but fixes it for the integration test battery - although I think this is a better fix than outright ignoring errors..

I used an older version of your branch when I started work on this, so, if you decide you want it then you might be better cutting - pasting or cherrypicking. 