### PR TITLE
Add warning about recurrence fmt 1 in Cylc7 back-compat mode

### DIFF
--- a/cylc/flow/time_parser.py
+++ b/cylc/flow/time_parser.py
@@ -45,6 +45,7 @@ from cylc.flow.exceptions import (
     CylcMissingFinalCyclePointError,
     CylcTimeSyntaxError,
 )
+import cylc.flow.flags
 
 if TYPE_CHECKING:
     from metomi.isodatetime.data import TimePoint
@@ -297,6 +298,15 @@ class CylcTimeParser:
                 LOG.warning(
                     "Cannot have more than 1 repetition for zero-duration "
                     f"recurrence {expression}."
+                )
+
+            if cylc.flow.flags.cylc7_back_compat and format_num == 1:
+                LOG.warning(
+                    f"The recurrence '{expression}' is unlikely to behave "
+                    "the same way as in Cylc 7 as that implementation was "
+                    "incorrect (see https://cylc.github.io/cylc-doc/latest/"
+                    "html/user-guide/writing-workflows/scheduling.html"
+                    "#format-1-r-limit-datetime-datetime)"
                 )
 
             return TimeRecurrence(

--- a/tests/functional/deprecations/03-suiterc.t
+++ b/tests/functional/deprecations/03-suiterc.t
@@ -17,8 +17,11 @@
 #------------------------------------------------------------------------------
 # Test backwards compatibility for suite.rc files
 
+# Includes a test for warning about recurrence format 1 which changed
+# implementation - https://github.com/cylc/cylc-flow/pull/4554
+
 . "$(dirname "$0")/test_header"
-set_test_number 2
+set_test_number 3
 
 init_suiterc() {
     local TEST_NAME="$1"
@@ -33,8 +36,9 @@ init_suiterc "${TEST_NAME_BASE}" <<'__FLOW__'
 [scheduler]
     allow implicit tasks = True
 [scheduling]
+    initial cycle point = 2000
     [[graph]]
-        R1 = foo => bar
+        R2/2000/2001 = foo => bar
 __FLOW__
 
 MSG=$(python -c 'from cylc.flow.workflow_files import SUITERC_DEPR_MSG;
@@ -42,4 +46,6 @@ print(SUITERC_DEPR_MSG)')
 
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate .
-grep_ok "$MSG" "${TEST_NAME_BASE}-validate.stderr"
+grep_ok "$MSG" "${TEST_NAME}.stderr"
+grep_ok "The recurrence 'R2/2000/2001' is unlikely to behave the same way as in Cylc 7 " \
+    "${TEST_NAME}.stderr"


### PR DESCRIPTION
Is it worth warning about recurrence format 1 in Cylc 7 back compat mode, seeing as it's easy to do?
