### PR TITLE
Tui test suppress scan errors

### DIFF
--- a/cylc/flow/tui/updater.py
+++ b/cylc/flow/tui/updater.py
@@ -230,7 +230,8 @@ class Updater():
         # do a workflow scan if it's due
         update_start_time = time()
         if update_start_time - last_scan_time > self.BASE_SCAN_INTERVAL:
-            data = await self._scan()
+            with suppress(Exception):
+                data = await self._scan()
 
         # get the next snapshot from workflows we are subscribed to
         update = await self._run_update(data)


### PR DESCRIPTION
There's some suggestion that splitting the Tui tests out of the bunch improves stability.

This infers that other tests running at the same time are somehow interfering with the Tui tests (which have generous timeouts so shouldn't fail for performance reasons).

Our tests rapidly add/remove workflows and sometimes create workflow files in broken states. I wondered if this is the root cause of the issue, so this PR is to test that theory...